### PR TITLE
feat: add a new setting could let other mod author add ignore item on their side

### DIFF
--- a/Source/TabSorting/IgnoreSettingDef.cs
+++ b/Source/TabSorting/IgnoreSettingDef.cs
@@ -1,0 +1,18 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Verse;
+
+namespace TabSorting;
+
+public class IgnoreSettingDef : Def
+{
+    public List<string> modIDsToIgnore;
+    public List<string> defsToIgnore;
+
+    public override void ResolveReferences()
+    {
+        base.ResolveReferences();
+        if (modIDsToIgnore?.Any() == true)
+            modIDsToIgnore = modIDsToIgnore.Select(id => id.ToLower()).ToList();
+    }
+}

--- a/Source/TabSorting/TabSorting.cs
+++ b/Source/TabSorting/TabSorting.cs
@@ -123,6 +123,8 @@ public static class TabSorting
 
         blueprintsLoaded = DefDatabase<DesignationDef>.GetNamedSilentFail("Blueprints") != null;
 
+        MergeIgnoresettingFromSettingDefs();
+
         refreshIgnoredDefs();
 
         DoTheSorting();
@@ -161,6 +163,29 @@ public static class TabSorting
             AccessTools.Method("ArchitectIcons.Resources:FindArchitectTabCategoryIcon");
         harmony.Patch(findArchitectTabCategoryIconMethod,
             new HarmonyMethod(typeof(TabSorting), nameof(architectIconsPrefix)));
+    }
+
+    /// <summary>
+    /// Search all ignore setting def from database, and then merge them into ignore hashset.
+    /// this provides a way to add ignore from other mods' side by using xml.
+    /// instead of creating PR then we put em inside those C# set manually.
+    ///
+    /// actually we could add namespace or other filters, but I think modID is quite enough.
+    /// </summary>
+    private static void MergeIgnoresettingFromSettingDefs()
+    {
+        var allIgnoresetting = DefDatabase<IgnoreSettingDef>.AllDefsListForReading;
+        foreach (var ignoreSetting in allIgnoresetting)
+        {
+            if (ignoreSetting.modIDsToIgnore != null)
+            {
+                modIdsToIgnore.UnionWith(ignoreSetting.modIDsToIgnore);
+            }
+            if (ignoreSetting.defsToIgnore != null)
+            {
+                defsToIgnoreStatic.UnionWith(ignoreSetting.defsToIgnore);
+            }
+        }
     }
 
     private static HashSet<string> DefsToIgnore


### PR DESCRIPTION
Hi! Thank you for providing such a great mod! I made some code change to add a new feature. Sorry for the closed PR, this is the first time I contribute into an opensource repo.

### What
This PR allows mod authors to exclude their mods from sorting automatically without needing to open a PR or contact the maintainers to update the hardcoded ignore HashSet.

### Why
Currently, if a mod or a specific Def needs to be ignored, it must be hardcoded into the ignore list within the C# code. This creates unnecessary delay and extra maintenance work. As a mod author, I believe it would be much more efficient if authors could configure this independently, rather than waiting for an upstream PR merge.

### How
- Introduced a new XML Def called `IgnoreSettingDef`, which can be implemented inside any mod (using `MayRequire` if necessary).
- Updated the C# logic to collect all `IgnoreSettingDef` configurations from loaded mods and merge them into the core ignore HashSet prior to the sorting process.